### PR TITLE
Fix bad path for mocha binary

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -34,7 +34,7 @@ module.exports = function (options, callback) {
 
     spawnOptions.cmd = require.resolve('mocha');
     spawnOptions.cmd = path.dirname(spawnOptions.cmd);
-    spawnOptions.cmd += '/../.bin/mocha';
+    spawnOptions.cmd += '/bin/mocha';
 
     if (process.platform === 'win32') {
         spawnOptions.cmd += '.cmd';


### PR DESCRIPTION
`require.resolve('mocha')` resoves to 'node_modules/mocha/index.js'
`path.dirname('node_modules/mocha/index.js')` logically resolves to 'node_modules/mocha/'

So, if you add '../.bin' you get 'nodes_modules/.bin' but the mocha binary is served in [the bin directory](https://github.com/visionmedia/mocha/tree/master/bin).
