### PR TITLE
Add env option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The list of test files to run can be specified using either the standard Grunt f
  * `quiet` (boolean) - disable printing of Mocha's output to the terminal.
  * `force` (boolean) - continue running Grunt tasks even if tests fail.
  * `files` (string|array) - glob(s) of test files to run.
+ * `env` (object) - hash of environment variables passed to the mocha process.
 
 
 ### Examples ###

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -45,6 +45,13 @@ module.exports = function (options, callback) {
         spawnOptions.opts = {stdio: 'inherit'};
     }
 
+    if (options.env) {
+        spawnOptions.env = process.env;
+        Object.keys(options.env).forEach(function (property) {
+            spawnOptions.env[property] = options.env[property];
+        });
+    }
+
     BOOL_OPTIONS.forEach(function (option) {
         if (options[option]) {
             args.push('--' + option);

--- a/test/fixture/env.js
+++ b/test/fixture/env.js
@@ -1,0 +1,8 @@
+'use strict';
+
+describe('fixture', function () {
+    it('has environment variable "FOO"', function () {
+        (Object.keys(process.env)).should.include('FOO');
+        process.env.FOO.should.equal('bar');
+    });
+});

--- a/test/mocha.js
+++ b/test/mocha.js
@@ -115,3 +115,19 @@ exports['file glob'] = function (test) {
         test.done();
     });
 };
+
+exports['set environment variable'] = function (test) {
+    test.expect(1);
+
+    mocha({
+        files: [__dirname + '/fixture/env.js'],
+        quiet: true,
+        require: ['should'],
+        env: {
+            FOO: 'bar'
+        }
+    }, function (error) {
+        test.ifError(error, 'should set environment variable "FOO"');
+        test.done();
+    });
+};


### PR DESCRIPTION
Hi there,

This commit allows us to set an optional hash of environment variables provided to the mocha process. It includes an update to the README as well as test coverage. 

Let me know if you have any concerns or change requests.

Cheers,

Sid
