### PR TITLE
moving to this.filesSrc instead of this.files

### DIFF
--- a/tasks/mochacli.js
+++ b/tasks/mochacli.js
@@ -7,14 +7,10 @@ module.exports = function (grunt) {
     grunt.registerMultiTask('mochacli', 'Run Mocha server-side tests.', function () {
         var done = this.async();
         var options = this.options();
-        var globs = [];
 
         // Use the Grunt files format if the `files` option isn't set
         if (!options.files) {
-            this.files.forEach(function (glob) {
-                globs = globs.concat(glob.orig.src);
-            });
-            options.files = globs;
+            options.files = this.filesSrc;
         }
 
         mocha(options, function (error) {

--- a/test/fixture/filter-gruntfile.js
+++ b/test/fixture/filter-gruntfile.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = function (grunt) {
+    grunt.initConfig({
+        mochacli: {
+            all: {
+                src: [__dirname + '/pass*.js'],
+                filter: function (file) {
+                    console.log('filter called with: ' + file);
+                    return (/pass2.js/).test(file);
+                }
+            }
+        }
+    });
+
+    grunt.loadTasks(__dirname + '/../../tasks');
+
+    grunt.registerTask('default', 'mochacli');
+};

--- a/test/mochacli.js
+++ b/test/mochacli.js
@@ -63,3 +63,16 @@ exports['grunt force'] = function (test) {
         test.done();
     });
 };
+
+exports['grunt filter works'] = function (test) {
+    test.expect(2);
+
+    grunt.util.spawn({
+        grunt: true,
+        args: ['--gruntfile', __dirname + '/fixture/filter-gruntfile.js']
+    }, function (error, output, code) {
+        test.notStrictEqual(output.stdout.indexOf('1 passing'), -1, 'should pass 1 test');
+        test.strictEqual(code, 0, 'grunt should pass');
+        test.done();
+    });
+};


### PR DESCRIPTION
This allows users to supply a filter function. This is done in the new test fixture, filter-gruntfile.js, taking the number of tests down to 1. The new test 'grunt filter works' verifies that this single test was run.
