### PR TITLE
Fixes indentation for use with `david` tool from `david-dm`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,41 +1,44 @@
 {
-    "name": "grunt-mocha-cli",
-    "description": "Run Mocha server-side tests in Grunt.",
-    "version": "1.3.0",
-    "author": "Roland Warmerdam (http://rolandwarmerdam.co.nz)",
-    "keywords": ["gruntplugin", "mocha"],
-    "homepage": "https://github.com/Rowno/grunt-mocha-cli",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Rowno/grunt-mocha-cli.git"
-    },
-    "licenses": [
-        {
-            "type": "MIT",
-            "url": "https://raw.github.com/Rowno/grunt-mocha-cli/master/LICENSE"
-        }
-    ],
-    "bugs": {
-        "url": "https://github.com/Rowno/grunt-mocha-cli/issues"
-    },
-    "engines": {
-        "node": "~0.10.0 || ~0.8.0"
-    },
-    "dependencies": {
-        "mocha": "~1.14.0"
-    },
-    "peerDependencies": {
-        "grunt": "~0.4.1"
-    },
-    "devDependencies": {
-        "coffee-script": "~1.6.3",
-        "grunt": "~0.4.1",
-        "grunt-contrib-jshint": "~0.6.3",
-        "grunt-contrib-nodeunit": "~0.2.0",
-        "should": "~1.3.0"
-    },
-    "scripts": {
-        "test": "grunt test"
-    },
-    "main": "lib/mocha"
+  "name": "grunt-mocha-cli",
+  "description": "Run Mocha server-side tests in Grunt.",
+  "version": "1.3.0",
+  "author": "Roland Warmerdam (http://rolandwarmerdam.co.nz)",
+  "keywords": [
+    "gruntplugin",
+    "mocha"
+  ],
+  "homepage": "https://github.com/Rowno/grunt-mocha-cli",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Rowno/grunt-mocha-cli.git"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://raw.github.com/Rowno/grunt-mocha-cli/master/LICENSE"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/Rowno/grunt-mocha-cli/issues"
+  },
+  "engines": {
+    "node": "~0.10.0 || ~0.8.0"
+  },
+  "dependencies": {
+    "mocha": "~1.14.0"
+  },
+  "peerDependencies": {
+    "grunt": "~0.4.1"
+  },
+  "devDependencies": {
+    "coffee-script": "~1.6.3",
+    "grunt": "~0.4.1",
+    "grunt-contrib-jshint": "~0.7.2",
+    "grunt-contrib-nodeunit": "~0.2.0",
+    "should": "~2.1.0"
+  },
+  "scripts": {
+    "test": "grunt test"
+  },
+  "main": "lib/mocha"
 }


### PR DESCRIPTION
`grunt-cli-mocha` is using [david-dm](https://david-dm.org/Rowno/grunt-mocha-cli) to track dependency updates. There exists an npm package [david](https://npmjs.org/package/david) that checks project dependencies for updates via the command `david update` and writes to `package.json`.

Previous to this commit, use of this tool would generate a meaningless diff due to the nonstandard `package.json` indentation in the `grunt-cli-mocha` project.

This commit regenerates `package.json` with david-compatible indentation for friendlier diffs.
