### PR TITLE
Add support for specifying node options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ The list of test files to run can be specified using either the standard Grunt f
  * `globals` (array) - allow the given comma-delimited global names.
  * `compilers` (array) - use the given module(s) to compile files.
  * `require` (array) - require the given modules.
+ * `expose-gc` (boolean) - expose gc extension, synonym for `node --expose-gc`.
+ * `gc-global` (boolean) - always perform global GCs, synonym for `node --gc-global`.
+ * `harmony` (boolean) - enable all harmony features (except typeof), synonym for `node --harmony`.
+ * `harmony-proxies` (boolean) - enable harmony proxies, synonym for `node --harmony-proxies`.
+ * `harmony-collections` (boolean) - enable harmony collections, synonym for `node --harmony-collections`.
+ * `harmony-generators` (boolean) - enable harmony generators, synonym for `node --harmony-generators`.
+ * `prof` (boolean) - Log statistical profiling information, synonym for `node --prof`.
 
 #### Extras ####
  * `quiet` (boolean) - disable printing of Mocha's output to the terminal.

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -17,7 +17,14 @@ var BOOL_OPTIONS = [
     'check-leaks',
     'sort',
     'inline-diffs',
-    'no-exit'
+    'no-exit',
+    'expose-gc',
+    'gc-global',
+    'harmony',
+    'harmony-proxies',
+    'harmony-collections',
+    'harmony-generators',
+    'prof'
 ];
 var STRING_OPTIONS = [
     'reporter',

--- a/test/fixture/option-nodejs-gruntfile.js
+++ b/test/fixture/option-nodejs-gruntfile.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = function (grunt) {
+    grunt.initConfig({
+        mochacli: {
+            options: {
+                harmony: true
+            },
+            all: [__dirname + '/proxy.js']
+        }
+    });
+
+    grunt.loadTasks(__dirname + '/../../tasks');
+
+    grunt.registerTask('default', 'mochacli');
+};
+

--- a/test/fixture/proxy.js
+++ b/test/fixture/proxy.js
@@ -1,0 +1,12 @@
+'use strict';
+
+/* global Proxy */
+
+var assert = require('assert');
+
+describe('fixture', function () {
+    it('should have Harmony Proxies', function () {
+        assert.notEqual(Proxy, null);
+    });
+});
+

--- a/test/mocha.js
+++ b/test/mocha.js
@@ -136,3 +136,16 @@ exports['save mocha output'] = function (test) {
         }
     });
 };
+
+exports['pass node.js options'] = function (test) {
+    test.expect(1);
+
+    mocha({
+        files: [__dirname + '/fixture/proxy.js'],
+        quiet: true,
+        'harmony-proxies': true
+    }, function (error) {
+        test.ifError(error);
+        test.done();
+    });
+};

--- a/test/mochacli.js
+++ b/test/mochacli.js
@@ -75,3 +75,15 @@ exports['option files'] = function (test) {
         test.done();
     });
 };
+
+exports['node.js options'] = function (test) {
+    test.expect(1);
+
+    grunt.util.spawn({
+        grunt: true,
+        args: ['--gruntfile', __dirname + '/fixture/option-nodejs-gruntfile.js']
+    }, function (error, output, code) {
+        test.strictEqual(code, 0, 'grunt should pass');
+        test.done();
+    });
+};


### PR DESCRIPTION
Mocha supports these through its launcher. This commit makes it possible
to pass them through via the grunt task.
