### PR TITLE
Update Mocha dependency to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">= 0.10.x"
   },
   "dependencies": {
-    "mocha": "~1.21.4"
+    "mocha": "~2.0.0"
   },
   "peerDependencies": {
     "grunt": "~0.4.1"


### PR DESCRIPTION
Mocha 2.0 was released to handle a deprecation in Node 0.11.14.  I think the "breaking" change was just deciding to no longer support Node 0.4 and 0.6, which shouldn't be an issue.
