### PR TITLE
Update Mocha dependency to 2.2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">= 0.10.x"
   },
   "dependencies": {
-    "mocha": "~2.1.0"
+    "mocha": "~2.2.0"
   },
   "peerDependencies": {
     "grunt": "~0.4.1"


### PR DESCRIPTION
There have been a lot of [bugfixes](https://github.com/mochajs/mocha/blob/3102c9bc395c3a542b492fb56011a3eba15f3b76/HISTORY.md#220--2015-03-06) in the 2.2.0, one in [particular](https://github.com/mochajs/mocha/pull/1440/files) that has been a bug bear of mine for a while.