### PR TITLE
Add support for starting with node-inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The list of test files to run can be specified using either the standard Grunt f
  * `files` (array) - globs of test files to run.
  * `filesRaw` (array) - globs of test files to run. These globs are passed directly to Mocha and aren't expanded by Grunt first.
  * `force` (boolean) - continue running Grunt tasks even if tests fail.
+ * `inspector` (boolean) - start tests with node-inspector's debugger
  * `quiet` (boolean) - disable printing of Mocha's output to the terminal.
  * `save` (string) - write the mocha output to a file.
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -51,6 +51,30 @@ var ARRAY_OPTIONS = [
 
 
 module.exports = function (options, callback) {
+    function tryRequire(module) {
+        try {
+            return require(module);
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function binpath(module, executable) {
+        var binext = (process.platform === 'win32' ? '.cmd' : '');
+        var moddir;
+        try {
+            moddir = path.dirname(require.resolve(module));
+        } catch (e) {
+            return null;
+        }
+        var exepath = path.join(moddir, '..', '.bin', executable + binext);
+        if (!grunt.file.exists(exepath) && which) {
+            // Check global install location instead
+            exepath = which.sync(executable);
+        }
+        return exepath;
+    }
+
     var args = [];
     var spawnOptions = {
         opts: {
@@ -58,12 +82,17 @@ module.exports = function (options, callback) {
         }
     };
 
-    spawnOptions.cmd = require.resolve('mocha');
-    spawnOptions.cmd = path.dirname(spawnOptions.cmd);
-    spawnOptions.cmd += '/../.bin/mocha';
+    var which = tryRequire('which');
+    var inspector = tryRequire('node-inspector');
 
-    if (process.platform === 'win32') {
-        spawnOptions.cmd += '.cmd';
+    if (options.inspector) {
+        spawnOptions.cmd = binpath('node-inspector', 'node-debug');
+        if (!inspector || !spawnOptions.cmd) {
+            grunt.fail.warn('Using the inspector option requires all optional dependencies to be installed');
+        }
+        args.push(binpath('mocha', '_mocha'));
+    } else {
+        spawnOptions.cmd = binpath('mocha', 'mocha');
     }
 
     if (!options.quiet && !options.save) {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
     "load-grunt-tasks": "~3.1.0",
     "should": "~5.2.0"
   },
+  "optionalDependencies": {
+    "node-inspector": "^0.9.2",
+    "which": "^1.0.9"
+  },
   "scripts": {
     "test": "grunt test"
   },


### PR DESCRIPTION
Hello Rowno :)

I'm not sure about the approach so please comment if you'd like something done differently or if I am missing something obvious on how to do it without. I would like to be able to pass `--inspector` to my grunt target to automatically start mocha with node-debug so I can debug the test in a browser.

I made node-inspector and which optional dependencies because I didn't want the install to be unnecessarily heavy, not sure if this is the right thing to do. I don't know if its sensibly possible to test this, because starting mocha would open the browser with the test. Let me know if you have an idea. 