### PR TITLE
handle case when options.files is empty

### DIFF
--- a/tasks/mochacli.js
+++ b/tasks/mochacli.js
@@ -2,6 +2,12 @@
 
 var mocha = require('../lib/mocha');
 
+var _filesExist = function(files) {
+    return (
+        (files instanceof Array && files.length > 0) ||
+        (files instanceof String && files.length > 0)
+    );
+};
 
 module.exports = function (grunt) {
     grunt.registerMultiTask('mochacli', 'Run Mocha server-side tests.', function () {
@@ -15,8 +21,13 @@ module.exports = function (grunt) {
             options.files = this.filesSrc;
         }
 
-        mocha(options, function (error) {
-            done(options.force ? true : error);
-        });
+        // Don't run mocha if there isn't any file specified
+        if (_filesExist(options.files)) {
+            mocha(options, function (error) {
+                done(options.force ? true : error);
+            });
+        } else {
+            done(true);
+        }
     });
 };


### PR DESCRIPTION
one typical case we could see a empty options.files is:

user passes in a options.files = [ 'demo/\*\*/\_\_tests\_\_/\*.js' ],
but actually there isn't any file in demo directory that match this pattern,
so after grunt.file.expand we'll see an empty option.files.

Right now for this case we'll see errors like this

```
/home/vagrant/uif/node_modules/mocha/lib/utils.js:592
      if (!files.length) throw new Error("cannot resolve path (or pattern) '"
                               ^
Error: cannot resolve path (or pattern) 'test'
    at Object.lookupFiles (/home/vagrant/uif/node_modules/mocha/lib/utils.js:592:32)
    at runAgain (/home/vagrant/uif/node_modules/mocha/bin/_mocha:320:30)
    at Array.forEach (native)
    at Object.<anonymous> (/home/vagrant/uif/node_modules/mocha/bin/_mocha:319:6)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:935:3
```

which may not be reasonable.