### PR TITLE
Arbitrary node arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The list of test files to run can be specified using either the standard Grunt f
  * `force` (boolean) - continue running Grunt tasks even if tests fail.
  * `quiet` (boolean) - disable printing of Mocha's output to the terminal.
  * `save` (string) - write the mocha output to a file.
-
+ * `args` (string) - pass arbitrary arguments to mocha.  Anything not recgonized by mocha will be passed to node.
 
 ### Examples ###
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -124,6 +124,10 @@ module.exports = function (options, callback) {
         }
     }
 
+    if (options.nodeArgs) {
+        args = args.concat(options.nodeArgs);
+    }
+
     if (options.files) {
         args = args.concat(options.files);
     }

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -124,8 +124,8 @@ module.exports = function (options, callback) {
         }
     }
 
-    if (options.nodeArgs) {
-        args = args.concat(options.nodeArgs);
+    if (options.args) {
+        args = args.concat(options.args);
     }
 
     if (options.files) {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "mocha": "~2.2.1"
+    "mocha": "~2.3.3"
   },
   "devDependencies": {
     "coffee-script": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-mocha-cli",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Run Mocha server-side tests in Grunt.",
   "author": "Roland Warmerdam (https://roland.codes)",
   "keywords": [


### PR DESCRIPTION
Node 4.x comes with a whole new set of harmony flags, among other things. [Mocha 2.3.3](https://github.com/mochajs/mocha/commit/c4647bf2fa167501e40d1c9a3858b09eae741700) added support for these in a generic sort of way.   

Instead of updating the long list of arguments, this simply adds the ability to specify an arbitrary list of arguments to mocha. 

Also updates mocha to 2.3.3.