### PR TITLE
Missing loadNpmTasks in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ grunt.initConfig({
         all: ['test/*.js']
     }
 });
-
+grunt.loadNpmTasks('grunt-mocha-cli');
 grunt.registerTask('test', ['mochacli']);
 ```
 
@@ -113,7 +113,7 @@ grunt.initConfig({
         }
     }
 });
-
+grunt.loadNpmTasks('grunt-mocha-cli');
 grunt.registerTask('test', ['mochacli:spec']);
 ```
 


### PR DESCRIPTION
Very simple change in Readme.md to include loadNpmTasks command. 
Without that grunt will not pick up testing framework.