### PR TITLE
Issue #39 - allow developers to pick their own version of mocha.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Getting Started
 If you haven't used [Grunt][] before, be sure to check out the [Getting Started][] guide, as it explains how to create a Gruntfile as well as install and use Grunt plugins. You can install this plugin with this command:
 
 ```bash
-npm install grunt-mocha-cli --save-dev
+npm install mocha grunt-mocha-cli --save-dev
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
   "engines": {
     "node": ">=0.10.0"
   },
-  "dependencies": {
-    "mocha": "~2.3.3"
-  },
   "devDependencies": {
     "coffee-script": "^1.9.1",
     "eslint-config-rowno": "^2.1.0",
@@ -22,6 +19,7 @@
     "grunt-contrib-nodeunit": "^0.4.0",
     "grunt-eslint": "^17.1.0",
     "load-grunt-tasks": "^3.2.0",
+    "mocha": "~2.4.5",
     "should": "^7.0.1"
   },
   "scripts": {


### PR DESCRIPTION
Remove the update treadmill, and support users who may have already been using mocha previously (the current package.json may cause the user to be running a version of mocha other than the one they expected).
