### PR TITLE
updated main to tasks/mochacli.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "test": "grunt test"
   },
-  "main": "lib/mocha",
+  "main": "tasks/mochacli.js",
   "files": [
     "lib",
     "tasks"


### PR DESCRIPTION
Thank you for this plugin, it's awesome.

I believe the entry point in the package.json should point to "main": "tasks/mochacli.js".  

It seems trivial, but causes problems if you're running grunt from outside of your project and need to use require('grunt-mocha-cli')(grunt);

This change fixes that and makes the the plugin more accessible for non-traditional implementations.