### PR TITLE
do not reject promise on error, if saving output to file

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -133,21 +133,20 @@ module.exports = function(options) {
     grunt.util.spawn(spawnOptions, (error, output) => {
       const combinedOutput = output.stdout + output.stderr
 
+      if (options.save) {
+        fs.writeFile(options.save, combinedOutput, error => {
+          if (error) {
+            return reject(error)
+          }
+        })
+      }
+
       if (error) {
         error.output = combinedOutput
         return reject(error)
       }
 
-      if (options.save) {
-        fs.writeFile(options.save, output.stdout, error => {
-          if (error) {
-            return reject(error)
-          }
-          resolve(combinedOutput)
-        })
-      } else {
-        resolve(combinedOutput)
-      }
+      resolve(combinedOutput)
     })
   })
 }


### PR DESCRIPTION
This change fixes a bug, where a failed mocha test does not get saved to output with the 'save' option.  

The failed mocha test is in the error output so, we don't want to reject the promise before it has the opportunity to write the output when using the 'save' option.

Basically, only reject the promise here, if we're not saving the output, otherwise continue.